### PR TITLE
Fixed a bug related to pagination: index.html => posts/2

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -10,10 +10,10 @@ layout: default
 {% if paginator.total_pages > 1 %}
     <nav id="pagenavi">
         {% if paginator.previous_page %}
-            <a href="{{paginator.previous_page}}" class="prev">Previous</a>
+            <a href="{{paginator.previous_page_path}}" class="prev">Previous</a>
         {% endif %}
         {% if paginator.next_page %}
-            <a href="{{paginator.next_page}}" class="next">Next</a>
+            <a href="{{paginator.next_page_path}}" class="next">Next</a>
         {% endif %}
     </nav>
 {% endif %}


### PR DESCRIPTION
Current configuration can't resolve the "next button", it sends you from domain.com to domain.com/2 , but if you have default configuration it should send you to domain.com/posts/2 . Also, when hitting "Previous" from domain.com/posts/2 it sends you to domain.com/posts/1 instead of domain.com
